### PR TITLE
chore(release): 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,41 @@
+## 1.0.0 (2025-03-17)
+
+
+### Features
+* output directory and output file prefix is remembered when submitting the same scene (#188) ([`1db21c6`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/1db21c6617dc3b44f6149df707642b42956fb061))
+* Enable GPU rendering from submitter ([`7a4f8bc`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/7a4f8bc28f55059b77a6f6d31baa39766fe56c98))
+* **adaptor**: Add BLENDER_EXECUTABLE environment variable (#156) ([`234c086`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/234c086d3b2626902aba76268f15f3c5e906953d))
+* public release (#80) ([`e5af3b7`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/e5af3b71f90b80f2b932220ffe6a1ce044542528))
+* swap to qtpy (#75) ([`b5c0c3a`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/b5c0c3ad09729b63a0431f07a9c2ffa68b7f27f3))
+* Adds telemetry events to submitter and adaptor (#63) ([`8f0fb2d`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/8f0fb2d85f2c9054eaceb384df1cd4711ec76ed6))
+* updated openjd-runtime to 0.5.* (#54) ([`3fcc0e8`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/3fcc0e8dff8790cb856b8e3e1c86cdeffc6bffea))
+* initial new blender integration (#37) ([`3180e48`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/3180e4876ec8f531827aebd2daff9a92ff5753d8))
+
+### Bug Fixes
+* "All Renderable Layers" option renders only one layer per task ([`c235b8e`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/c235b8eb646f63503f27930b23be6dbb6bfb90eb))
+* Add OCIO configuration support in SMF ([`3da609b`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/3da609b425cb9eab827b87fc0ff5b1179d6e7854))
+* Apply output file prefixes to submitter GUI ([`876348a`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/876348ac5eb8aec11b784dfe83e7ca46570c4793))
+* Handle '//' in output directories ([`985d5a3`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/985d5a34568706d952d91d43b5910bf9135072e6))
+* Use user-specified output directories when applicable ([`e6e97ae`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/e6e97ae058e014d98d9212f1280a53edbe4db646))
+* **adaptor**: eevee render engine rename to BLENDER_EEVEE_NEXT for 4.2 (#139) ([`e848012`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/e8480129244c3dc597d20ce06685eab38fc66a84))
+* Classify auto-detected assets correctly ([`31f9229`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/31f92296ff795c41daee37648add5ab97ea3860d))
+* Enable close button  on the submitter dialog in Blender 4.2 (#127) ([`c9582ea`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/c9582eaa46fa09b9829b3bae2ec390436bf022b7))
+* Use python-use-system-env to have Blender check PYTHONPATH. (#125) ([`c73bbe2`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/c73bbe2058fb2e61e80d8577164bc229790a6e0d))
+* correct adaptor override developer option (#117) ([`b8be198`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/b8be1989dfd745cfc04adde35a70b836da0591b5))
+* exclude view layers if not used for rendering (#92) ([`fe29282`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/fe29282bb5fe041ff0a9508054ebfaa0410b0aad))
+* set frame override and remove job_settings.py (#91) ([`7a350bb`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/7a350bbb60c8340a235ba5fbbd1268df800428c1))
+* override frame range checkbox (#90) ([`a900d7c`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/a900d7cff01ef51510f16f427416026a8b431ec8))
+* Prevents the submission dialog from locking Blender on Linux (#81) ([`7730b11`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/7730b11cf32e0de9756e5c16ee4c349a96e62774))
+* include the adaptor deps in the package (#79) ([`fe6f0af`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/fe6f0af9726d10e1bac4c9ad3d3f8500be249e61))
+* incorrect package name in create adaptor script (#78) ([`7b92e91`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/7b92e91fa1edc6c2974f80971afe93194d745797))
+* include the adaptor deps in the package (#74) ([`ae09907`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/ae0990753d0f31dbf8cfd4805191b44661458c9e))
+* include deadline-cloud in the adaptor packaging script (#73) ([`9de3146`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/9de31469a1485901d40a0993cbee36838c8774fa))
+* **hidden**: make frame progress regex more accurate (#58) ([`b3df92d`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/b3df92da71d80fbf734e7c165d17f82fb97cd7e9))
+* remove variables from bl_info (#53) ([`4d0cda6`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/4d0cda637d6f66604c86f341ab33d605e70ecdf3))
+* adaptor client changes for windows (#47) ([`b69a0df`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/b69a0df940e5eab6631079dbb271e8b18aba4d1f))
+* create module dir if it doesn't exist in installation (#43) ([`301f1e6`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/301f1e6d01cb8fccc52a3bec8ce47aa6ed70576a))
+* temporary remove icon until production icons are finalised (#15) ([`40df787`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/40df78706e8a253656bea764b06bcca9c80bd285))
+
 ## 0.1.0 (2025-03-17)
 
 

--- a/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/__init__.py
+++ b/src/deadline/blender_submitter/addons/deadline_cloud_blender_submitter/__init__.py
@@ -21,7 +21,7 @@ bl_info = {
     "name": "Deadline Cloud for Blender",
     "description": "Submit to AWS Deadline Cloud",
     "author": "AWS",
-    "version": (0, 1, 0),
+    "version": (1, 0, 0),
     "blender": (3, 6, 0),
     "category": "Render",
 }


### PR DESCRIPTION
## 1.0.0 (2025-03-17)


### Features
* output directory and output file prefix is remembered when submitting the same scene (#188) ([`1db21c6`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/1db21c6617dc3b44f6149df707642b42956fb061))
* Enable GPU rendering from submitter ([`7a4f8bc`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/7a4f8bc28f55059b77a6f6d31baa39766fe56c98))
* **adaptor**: Add BLENDER_EXECUTABLE environment variable (#156) ([`234c086`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/234c086d3b2626902aba76268f15f3c5e906953d))
* public release (#80) ([`e5af3b7`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/e5af3b71f90b80f2b932220ffe6a1ce044542528))
* swap to qtpy (#75) ([`b5c0c3a`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/b5c0c3ad09729b63a0431f07a9c2ffa68b7f27f3))
* Adds telemetry events to submitter and adaptor (#63) ([`8f0fb2d`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/8f0fb2d85f2c9054eaceb384df1cd4711ec76ed6))
* updated openjd-runtime to 0.5.* (#54) ([`3fcc0e8`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/3fcc0e8dff8790cb856b8e3e1c86cdeffc6bffea))
* initial new blender integration (#37) ([`3180e48`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/3180e4876ec8f531827aebd2daff9a92ff5753d8))

### Bug Fixes
* "All Renderable Layers" option renders only one layer per task ([`c235b8e`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/c235b8eb646f63503f27930b23be6dbb6bfb90eb))
* Add OCIO configuration support in SMF ([`3da609b`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/3da609b425cb9eab827b87fc0ff5b1179d6e7854))
* Apply output file prefixes to submitter GUI ([`876348a`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/876348ac5eb8aec11b784dfe83e7ca46570c4793))
* Handle '//' in output directories ([`985d5a3`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/985d5a34568706d952d91d43b5910bf9135072e6))
* Use user-specified output directories when applicable ([`e6e97ae`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/e6e97ae058e014d98d9212f1280a53edbe4db646))
* **adaptor**: eevee render engine rename to BLENDER_EEVEE_NEXT for 4.2 (#139) ([`e848012`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/e8480129244c3dc597d20ce06685eab38fc66a84))
* Classify auto-detected assets correctly ([`31f9229`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/31f92296ff795c41daee37648add5ab97ea3860d))
* Enable close button  on the submitter dialog in Blender 4.2 (#127) ([`c9582ea`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/c9582eaa46fa09b9829b3bae2ec390436bf022b7))
* Use python-use-system-env to have Blender check PYTHONPATH. (#125) ([`c73bbe2`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/c73bbe2058fb2e61e80d8577164bc229790a6e0d))
* correct adaptor override developer option (#117) ([`b8be198`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/b8be1989dfd745cfc04adde35a70b836da0591b5))
* exclude view layers if not used for rendering (#92) ([`fe29282`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/fe29282bb5fe041ff0a9508054ebfaa0410b0aad))
* set frame override and remove job_settings.py (#91) ([`7a350bb`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/7a350bbb60c8340a235ba5fbbd1268df800428c1))
* override frame range checkbox (#90) ([`a900d7c`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/a900d7cff01ef51510f16f427416026a8b431ec8))
* Prevents the submission dialog from locking Blender on Linux (#81) ([`7730b11`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/7730b11cf32e0de9756e5c16ee4c349a96e62774))
* include the adaptor deps in the package (#79) ([`fe6f0af`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/fe6f0af9726d10e1bac4c9ad3d3f8500be249e61))
* incorrect package name in create adaptor script (#78) ([`7b92e91`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/7b92e91fa1edc6c2974f80971afe93194d745797))
* include the adaptor deps in the package (#74) ([`ae09907`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/ae0990753d0f31dbf8cfd4805191b44661458c9e))
* include deadline-cloud in the adaptor packaging script (#73) ([`9de3146`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/9de31469a1485901d40a0993cbee36838c8774fa))
* **hidden**: make frame progress regex more accurate (#58) ([`b3df92d`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/b3df92da71d80fbf734e7c165d17f82fb97cd7e9))
* remove variables from bl_info (#53) ([`4d0cda6`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/4d0cda637d6f66604c86f341ab33d605e70ecdf3))
* adaptor client changes for windows (#47) ([`b69a0df`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/b69a0df940e5eab6631079dbb271e8b18aba4d1f))
* create module dir if it doesn't exist in installation (#43) ([`301f1e6`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/301f1e6d01cb8fccc52a3bec8ce47aa6ed70576a))
* temporary remove icon until production icons are finalised (#15) ([`40df787`](https://github.com/erico-aws/deadline-cloud-for-blender/commit/40df78706e8a253656bea764b06bcca9c80bd285))
